### PR TITLE
Fix race condition while appending new page

### DIFF
--- a/lib/pager.dart
+++ b/lib/pager.dart
@@ -401,7 +401,9 @@ class _PagerState<K, T> extends State<Pager<K, T>> with AutomaticKeepAliveClient
 
 
     if ((_totalNumberOfItems - scrollOffsetPerItem) <= prefetchDistance) {
-      _doLoad(LoadType.APPEND);
+      if(_states.append is! Loading && !_states.append.endOfPaginationReached) {
+        _doLoad(LoadType.APPEND);
+      }
     }
   }
 


### PR DESCRIPTION
**What's done**
- Fix race condition while fetching the next page, pages are fetched concurrently causing loading unexpected pages.