### PR TITLE
Fix for concurrent modification issue when closing page subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.0.1
 
 * initial release.
+
+## 0.0.2
+
+* Fixed concurrent modification issue when closing page subscriptions.

--- a/lib/pager.dart
+++ b/lib/pager.dart
@@ -25,10 +25,10 @@ typedef PagingBuilder<T> = Widget Function(BuildContext context, T value);
 class Pager<K, T> extends StatefulWidget {
   const Pager({
     Key? key,
-    required this.source,
-    required this.builder,
-    this.pagingConfig = const PagingConfig.fromDefault(),
-    this.scrollController,
+      required this.source,
+      required this.builder,
+      this.pagingConfig = const PagingConfig.fromDefault(),
+      this.scrollController,
     this.keepAlive = false
   }) : super(key: key);
 
@@ -80,7 +80,7 @@ class _PagerState<K, T> extends State<Pager<K, T>> with AutomaticKeepAliveClient
 
   /// Holds a subscription for each page fetched
   final LinkedHashMap<K?, StreamSubscription<Page<K, T>>> _pageSubscriptions =
-  LinkedHashMap();
+      LinkedHashMap();
 
   ///
   PagingSource<K, T>? _pagingSource;
@@ -365,9 +365,12 @@ class _PagerState<K, T> extends State<Pager<K, T>> with AutomaticKeepAliveClient
 
   /// It's paramount that this ends before any other subscription is added
   _closeAllSubscriptions() async {
-    if(_pageSubscriptions.isEmpty) return;
+    if (_pageSubscriptions.isEmpty) return;
+
+    final subscriptions = [..._pageSubscriptions.entries];
+
     await Future.microtask(() async {
-      for (final subscription in _pageSubscriptions.entries) {
+      for (final subscription in subscriptions) {
         await subscription.value.cancel();
       }
       _pageSubscriptions.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: pager
 description: A Paging Library for fetch data both locally or remotely
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/donpaul120/pager
 repository: https://github.com/donpaul120/pager
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.16.1 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
I observed an issue in widget tests where `_closeAllSubscriptions` was called twice because `invalidate` was invoked twice in rapid succession (last one in dispose method). This caused a concurrent modification race condition with the page subscriptions to happen after the tests have passed.

**FIX:**

Make a copy of page subscriptions to prevent concurrent modification issue when closing page subscriptions asynchronously.