### PR TITLE
Exposed totalItems for pager

### DIFF
--- a/lib/pager.dart
+++ b/lib/pager.dart
@@ -16,21 +16,20 @@ import 'paging/paging_state.dart';
 import 'paging/remote_mediator.dart';
 import 'package:collection/collection.dart';
 
-
 /// @author Paul Okeke
 /// A Paging Library
 
 typedef PagingBuilder<T> = Widget Function(BuildContext context, T value);
 
 class Pager<K, T> extends StatefulWidget {
-  const Pager({
-    Key? key,
-    required this.source,
-    required this.builder,
-    this.pagingConfig = const PagingConfig.fromDefault(),
-    this.scrollController,
-    this.keepAlive = false
-  }) : super(key: key);
+  const Pager(
+      {Key? key,
+      required this.source,
+      required this.builder,
+      this.pagingConfig = const PagingConfig.fromDefault(),
+      this.scrollController,
+      this.keepAlive = false})
+      : super(key: key);
 
   final PagingSource<K, T> source;
 
@@ -292,7 +291,11 @@ class _PagerState<K, T> extends State<Pager<K, T>> with AutomaticKeepAliveClient
 
     if (result is MediatorSuccess) {
       mediatorStates = mediatorStates?.modifyState(
-          loadType, NotLoading(result.endOfPaginationReached)
+        loadType,
+        NotLoading(
+          result.endOfPaginationReached,
+          totalItems: result.totalItems,
+        ),
       );
       _doLoad(loadType);
     } else if (result is MediatorError) {

--- a/lib/paging/load_state.dart
+++ b/lib/paging/load_state.dart
@@ -1,14 +1,18 @@
-
 class LoadState {
   final bool endOfPaginationReached;
-  LoadState(this.endOfPaginationReached);
+  final int? totalItems;
+
+  LoadState(this.endOfPaginationReached, {this.totalItems = 0});
+
   String toString() {
-    return "LoadState(endOfPaginationReached=$endOfPaginationReached)";
+    return "LoadState(endOfPaginationReached=$endOfPaginationReached, totalItems=$totalItems)";
   }
 }
 
 class NotLoading extends LoadState {
-  NotLoading(bool endOfPaginationReached): super(endOfPaginationReached);
+  NotLoading(bool endOfPaginationReached, {int? totalItems})
+      : super(endOfPaginationReached, totalItems: totalItems);
+
   @override
   String toString() {
     return "NotLoading(endOfPaginationReached=$endOfPaginationReached)";

--- a/lib/paging/remote_mediator.dart
+++ b/lib/paging/remote_mediator.dart
@@ -8,16 +8,25 @@ abstract class RemoteMediator<K, V> extends ValueNotifier<MediatorResult?> {
 }
 
 class MediatorResult {
+  final int totalItems;
 
-  MediatorResult();
+  MediatorResult({this.totalItems = 0});
 
-  factory MediatorResult.success({bool endOfPaginationReached = true}) => MediatorSuccess(endOfPaginationReached);
-  factory MediatorResult.error({required Exception exception}) => MediatorError(exception);
+  factory MediatorResult.success({
+    bool endOfPaginationReached = true,
+    int totalItems = 0,
+  }) =>
+      MediatorSuccess(endOfPaginationReached, totalItems);
+
+  factory MediatorResult.error({required Exception exception}) =>
+      MediatorError(exception);
 }
 
 class MediatorSuccess extends MediatorResult {
   final bool endOfPaginationReached;
-  MediatorSuccess(this.endOfPaginationReached);
+
+  MediatorSuccess(this.endOfPaginationReached, int totalItems)
+      : super(totalItems: totalItems);
 
   @override
   String toString() {


### PR DESCRIPTION
What's done:
- Exposed totalItems from the PageRecordResponse, useful when devs want to show total number of items to be loaded ahead of time like showing a title - **Transactions (1300)**