### PR TITLE
Add prepend support to PagerController

### DIFF
--- a/lib/paging/load_states.dart
+++ b/lib/paging/load_states.dart
@@ -14,6 +14,19 @@ class LoadStates {
         "source=null, mediator=null)";
   }
 
+  /// Read counterpart of [modifyState], so callers handling both directions
+  /// don't have to fork into `.append`/`.prepend` branches.
+  LoadState get(LoadType type) {
+    switch (type) {
+      case LoadType.REFRESH:
+        return refresh;
+      case LoadType.APPEND:
+        return append;
+      case LoadType.PREPEND:
+        return prepend;
+    }
+  }
+
   LoadStates modifyState(LoadType type, LoadState newState) {
     switch(type) {
       case LoadType.REFRESH:{
@@ -26,18 +39,49 @@ class LoadStates {
     }
   }
 
-  LoadStates combineStates(LoadStates localState, LoadStates remoteState){
-    LoadState aRefresh = LoadState(false);
-    LoadState aAppend = LoadState(false);
-
-    aRefresh = (remoteState.refresh is Loading) ? remoteState.refresh : localState.refresh;
-    aAppend = (remoteState.append is Loading) ? remoteState.append : localState.append;
-
-    if(remoteState.refresh is Error || localState.refresh is Error) {
+  /// [hasMediator] must be true when a [RemoteMediator] is present.
+  /// Without it, only the local source determines end-of-pagination (original
+  /// behaviour). With it, both source AND mediator must confirm no more data
+  /// before [endOfPaginationReached] becomes true — preventing a premature
+  /// "end of list" when the local cache is empty but the server has more.
+  ///
+  /// [Error] and [Loading] states from either side always take precedence over
+  /// the combined end-of-pagination flags, so failures and in-flight loads are
+  /// never masked from the UI.
+  LoadStates combineStates(LoadStates localState, LoadStates remoteState,
+      {bool hasMediator = false}) {
+    // Refresh deliberately ranks errors above Loading (a failed refresh must
+    // surface even while the other side retries), unlike _combineDirection,
+    // and never ANDs end-of-pagination flags.
+    final LoadState aRefresh;
+    if (remoteState.refresh is Error) {
       aRefresh = remoteState.refresh;
+    } else if (localState.refresh is Error) {
+      aRefresh = localState.refresh;
+    } else if (remoteState.refresh is Loading) {
+      aRefresh = remoteState.refresh;
+    } else {
+      aRefresh = localState.refresh;
     }
 
-    return LoadStates(aRefresh, aAppend, prepend);
+    final aAppend =
+        _combineDirection(localState.append, remoteState.append, hasMediator);
+    final aPrepend =
+        _combineDirection(localState.prepend, remoteState.prepend, hasMediator);
+
+    return LoadStates(aRefresh, aAppend, aPrepend);
+  }
+
+  static LoadState _combineDirection(
+      LoadState local, LoadState remote, bool hasMediator) {
+    if (remote is Loading) return remote;
+    if (remote is Error) return remote;
+    if (local is Loading || local is Error) return local;
+    if (hasMediator) {
+      return NotLoading(
+          local.endOfPaginationReached && remote.endOfPaginationReached);
+    }
+    return local;
   }
 
   factory LoadStates.idle() => LoadStates(

--- a/lib/paging/pager_controller.dart
+++ b/lib/paging/pager_controller.dart
@@ -53,10 +53,9 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
   int _totalItems = 0;
   int? _mediatorTotalItems;
   bool _disposed = false;
-
-  // Set synchronously before the lock is acquired so that concurrent scroll
-  // events are rejected before they can queue another append on the lock.
-  bool _isAppendInFlight = false;
+  // Populated synchronously before the lock is acquired so that concurrent
+  // scroll events are rejected before they can queue another load on the lock.
+  final Set<LoadType> _loadsInFlight = {};
 
   RemoteMediator<K, dynamic>? get _remoteMediator => source.remoteMediator;
 
@@ -64,6 +63,18 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
 
   /// Total raw item count across all loaded pages (pre-group for grouped data).
   int get totalItems => _totalItems;
+
+  /// Manually triggers the next append load, bypassing end-of-pagination guards.
+  ///
+  /// Use when the built-in scroll detection does not suit your layout, or when
+  /// you know new data has arrived on the server. Safe to call concurrently —
+  /// an in-flight load absorbs duplicate calls.
+  void triggerAppend() => _doLoad(LoadType.APPEND, bypassEndOfPag: true);
+
+  /// Manually triggers the next prepend load, bypassing end-of-pagination guards.
+  ///
+  /// Same semantics as [triggerAppend] but for the leading direction.
+  void triggerPrepend() => _doLoad(LoadType.PREPEND, bypassEndOfPag: true);
 
   /// Flat list of currently loaded items.
   List<T> get items => value.data;
@@ -109,7 +120,7 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     _states = LoadStates.idle();
     _sourceStates = LoadStates.idle();
     _mediatorStates = LoadStates.idle();
-    _isAppendInFlight = false;
+    _loadsInFlight.clear();
     await _invalidate(dispatch: false);
     _doInitialLoad();
   }
@@ -132,15 +143,10 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
 
   /// Called by [Pager] (or manually) with the current scroll position.
   ///
-  /// Triggers an append load when the remaining visible items fall within
-  /// [PagingConfig.preFetchDistance].
+  /// Triggers an append load when remaining items fall within
+  /// [PagingConfig.preFetchDistance], and a prepend load when items above
+  /// the viewport fall within [PagingConfig.preFetchDistance].
   void onScrollPositionChanged(double currentPosition, double maxScrollExtent) {
-    if (_isAppendInFlight) return;
-    if (_sourceStates.append is Loading) return;
-    if (_sourceStates.append.endOfPaginationReached &&
-        (_remoteMediator == null ||
-            _mediatorStates.append.endOfPaginationReached)) return;
-
     if (maxScrollExtent <= 0 || _totalItems <= 0) return;
 
     final heightPerItem = maxScrollExtent / _totalItems;
@@ -149,9 +155,44 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     final scrollOffsetPerItem = currentPosition / heightPerItem;
     final remainingItems = _totalItems - scrollOffsetPerItem;
 
-    if (remainingItems <= pagingConfig.preFetchDistance) {
+    if (remainingItems <= pagingConfig.preFetchDistance &&
+        _canLoadFromScroll(LoadType.APPEND)) {
       _doLoad(LoadType.APPEND);
     }
+
+    if (scrollOffsetPerItem <= pagingConfig.preFetchDistance &&
+        _canLoadFromScroll(LoadType.PREPEND)) {
+      _doLoad(LoadType.PREPEND);
+    }
+  }
+
+  /// The key the next load in [type]'s direction starts from: the first
+  /// page's prevKey for prepends, the last page's nextKey otherwise.
+  K? _loadCursor(LoadType type) => type == LoadType.PREPEND
+      ? _pages.firstOrNull?.prevKey
+      : _pages.lastOrNull?.nextKey;
+
+  /// True when no further data can arrive in [type]'s direction: the source
+  /// has ended and — when a mediator exists — the mediator has too.
+  bool _isDirectionExhausted(LoadType type) =>
+      _sourceStates.get(type).endOfPaginationReached &&
+      (_remoteMediator == null ||
+          _mediatorStates.get(type).endOfPaginationReached);
+
+  /// Fast-path guard for scroll-triggered loads; [_doLoad] re-checks inside
+  /// the lock as the safety net.
+  bool _canLoadFromScroll(LoadType type) {
+    if (_loadsInFlight.contains(type)) return false;
+    if (_sourceStates.get(type) is Loading) return false;
+    if (_isDirectionExhausted(type)) return false;
+    // At a null boundary key with the end state already published, _doLoad is
+    // a guaranteed no-op — skip the per-scroll-frame lock round trip.
+    if (_pages.isNotEmpty &&
+        _loadCursor(type) == null &&
+        _sourceStates.get(type) == NotLoading(true)) {
+      return false;
+    }
+    return true;
   }
 
   // ─── Internal loading ─────────────────────────────────────────────────────
@@ -163,12 +204,9 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     });
   }
 
-  Future<void> _doLoad(LoadType loadType) async {
-    // Synchronously gate concurrent append calls before touching the lock.
-    if (loadType == LoadType.APPEND) {
-      if (_isAppendInFlight) return;
-      _isAppendInFlight = true;
-    }
+  Future<void> _doLoad(LoadType loadType, {bool bypassEndOfPag = false}) async {
+    // Synchronously gate concurrent append/prepend calls before touching the lock.
+    if (loadType != LoadType.REFRESH && !_loadsInFlight.add(loadType)) return;
 
     try {
       await _lock.synchronized(() async {
@@ -180,40 +218,48 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
         if (_pages.isEmpty || _pages.last.isEmpty()) {
           params = _buildParams(LoadType.REFRESH, null);
         } else {
-          params = _buildParams(loadType, _pages.last.nextKey);
+          params = _buildParams(loadType, _loadCursor(loadType));
         }
 
-        switch (loadType) {
-          case LoadType.REFRESH:
-            _sourceStates = _sourceStates.modifyState(loadType, Loading());
-            await _closeAllSubscriptions();
-            await _onRefresh(params);
-            break;
-
-          case LoadType.APPEND:
-            // Guards inside the lock as a safety net for any queued calls.
-            if (_sourceStates.append is Loading) return;
-            if (_sourceStates.append.endOfPaginationReached &&
-                (_remoteMediator == null ||
-                    _mediatorStates.append.endOfPaginationReached)) return;
-            if (_pages.isNotEmpty && _pages.last.nextKey == null) {
-              _sourceStates = _sourceStates.modifyState(
-                  LoadType.APPEND, NotLoading(true));
-              dispatchUpdates();
-              return;
-            }
-            _sourceStates = _sourceStates.modifyState(loadType, Loading());
-            await _onAppend(params);
-            break;
-
-          case LoadType.PREPEND:
-            break;
+        if (loadType == LoadType.REFRESH) {
+          _sourceStates = _sourceStates.modifyState(loadType, Loading());
+          await _closeAllSubscriptions();
+          await _onRefresh(params);
+          return;
         }
+
+        // Guards inside the lock as a safety net for any queued calls.
+        if (_sourceStates.get(loadType) is Loading) return;
+        if (!bypassEndOfPag && _isDirectionExhausted(loadType)) return;
+        // An empty list gives a prepend nothing to anchor to; an append falls
+        // back to the refresh-shaped params built above instead.
+        if (loadType == LoadType.PREPEND && _pages.isEmpty) return;
+
+        if (_pages.isNotEmpty && _loadCursor(loadType) == null) {
+          // The source has no further page in this direction. Only dispatch
+          // on an actual transition — scroll events near the boundary land
+          // here every frame and would otherwise rebuild the UI each time
+          // (PagingData has no ==, so every set notifies).
+          if (_sourceStates.get(loadType) != NotLoading(true)) {
+            _sourceStates =
+                _sourceStates.modifyState(loadType, NotLoading(true));
+            dispatchUpdates();
+          }
+          return;
+        }
+
+        // bypassEndOfPag also resets the mediator state so _requestRemoteLoad
+        // is not silently short-circuited by a stale endOfPaginationReached.
+        if (bypassEndOfPag &&
+            _mediatorStates.get(loadType).endOfPaginationReached) {
+          _mediatorStates =
+              _mediatorStates.modifyState(loadType, NotLoading(false));
+        }
+        _sourceStates = _sourceStates.modifyState(loadType, Loading());
+        await _onDirectionalLoad(loadType, params);
       });
     } finally {
-      if (loadType == LoadType.APPEND) {
-        _isAppendInFlight = false;
-      }
+      _loadsInFlight.remove(loadType);
     }
   }
 
@@ -249,10 +295,11 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
         }
         // Use nextKey as the authoritative end-of-pagination signal.
         final isEnd = page.nextKey == null;
+        final isPrependEnd = page.prevKey == null;
         _sourceStates = _sourceStates
             .modifyState(LoadType.REFRESH, NotLoading(isEnd))
             .modifyState(LoadType.APPEND, NotLoading(isEnd))
-            .modifyState(LoadType.PREPEND, NotLoading(true));
+            .modifyState(LoadType.PREPEND, NotLoading(isPrependEnd));
         _insertOrUpdate(params.key, page);
         // For empty pages, _insertOrUpdate won't dispatch — do it explicitly.
         if (page.isEmpty()) dispatchUpdates();
@@ -267,12 +314,36 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     _pageSubscriptions.putIfAbsent(params.key, () => subscription);
   }
 
-  FutureOr<void> _onAppend(LoadParams<K> params) async {
+  /// Shared handler for append and prepend loads — the two directions differ
+  /// only in which boundary key ends pagination, where the page is inserted,
+  /// and the prepend-only re-trigger after a mediator fetch.
+  FutureOr<void> _onDirectionalLoad(
+      LoadType direction, LoadParams<K> params) async {
     if (_pageSubscriptions.containsKey(params.key)) return;
 
+    final prepend = direction == LoadType.PREPEND;
     final completer = Completer<void>();
     StreamSubscription<Page<K, T>>? subscription;
     bool streamCompleted = false;
+    // Set once this load hits the data boundary and the mediator was asked
+    // for more.
+    bool remoteLoadRequested = false;
+
+    // Prepends re-run themselves once the mediator has saved new data: unlike
+    // appends, there may never be another scroll event at the top of the list
+    // to pick it up. Guarded against Error/end-of-pagination — and requiring a
+    // mediator at all — so an empty local result can never re-trigger in an
+    // infinite loop.
+    void retriggerIfMediatorSavedData() {
+      if (!prepend || _remoteMediator == null) return;
+      final mediatorState = _mediatorStates.get(direction);
+      if (mediatorState is Loading ||
+          mediatorState is Error ||
+          mediatorState.endOfPaginationReached) return;
+      Future.delayed(Duration.zero, () {
+        if (!_disposed) _doLoad(direction, bypassEndOfPag: true);
+      });
+    }
 
     final localSource = source.localSource.call(params);
 
@@ -285,25 +356,39 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
           return;
         }
 
-        // nextKey == null means this is the last page.
-        final endOfPage = page.nextKey == null;
+        // A null boundary key (nextKey for appends, prevKey for prepends)
+        // means the source has no further page in this direction.
+        final endOfPage = (prepend ? page.prevKey : page.nextKey) == null;
 
-        _sourceStates = _sourceStates
-            .modifyState(LoadType.REFRESH, NotLoading(true))
-            .modifyState(LoadType.APPEND, NotLoading(endOfPage))
-            .modifyState(LoadType.PREPEND, NotLoading(true));
+        final newState = NotLoading(endOfPage);
+        final stateChanged = _sourceStates.get(direction) != newState;
+        _sourceStates = _sourceStates.modifyState(direction, newState);
+        if (!prepend) {
+          _sourceStates =
+              _sourceStates.modifyState(LoadType.REFRESH, NotLoading(true));
+        }
 
-        // Use params.key as the position key so the page is always appended
-        // at the correct slot regardless of how the source sets page.prevKey.
-        _insertOrUpdate(params.key, page);
+        // Use params.key as the position key so the page always lands in the
+        // correct slot regardless of how the source sets its own keys. Empty
+        // first emissions (cache miss — the page exists only to trigger the
+        // mediator) are no-ops; empty re-emissions remove the page.
+        _insertOrUpdate(params.key, page, prepend: prepend);
+
+        // _insertOrUpdate only dispatches when the data changed; a load-state
+        // transition (e.g. Loading → NotLoading on an empty page) must still
+        // be published or `value` stays stuck on the stale state.
+        if (prepend && stateChanged) dispatchUpdates();
 
         if (page.data.isEmpty || endOfPage) {
+          remoteLoadRequested = true;
           subscription?.pause();
-          await _requestRemoteLoad(LoadType.APPEND);
+          await _requestRemoteLoad(direction);
           if (!streamCompleted) {
             subscription?.resume();
           } else {
+            // Stream completed while waiting for the mediator.
             _pageSubscriptions.remove(params.key);
+            retriggerIfMediatorSavedData();
           }
         }
 
@@ -312,20 +397,22 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
       onDone: () {
         streamCompleted = true;
         // Stream ended (one-shot source). Unstick any Loading state so the
-        // scroll guard recovers, and remove the subscription so a future scroll
+        // scroll guard recovers, and remove the subscription so a future load
         // can re-subscribe for new data (e.g. after a remote mediator load).
-        if (_sourceStates.append is Loading) {
+        if (_sourceStates.get(direction) is Loading) {
           _sourceStates =
-              _sourceStates.modifyState(LoadType.APPEND, NotLoading(true));
+              _sourceStates.modifyState(direction, NotLoading(true));
           dispatchUpdates();
         }
         _pageSubscriptions.remove(params.key);
         if (!completer.isCompleted) completer.complete();
+        // onDone fires after onData returned (streamCompleted was still false
+        // when onData checked), so re-trigger from here in that case.
+        if (remoteLoadRequested) retriggerIfMediatorSavedData();
       },
       onError: (Object e) {
         _sourceStates = _sourceStates.modifyState(
-            LoadType.APPEND,
-            Error(e is Exception ? e : Exception(e.toString())));
+            direction, Error(e is Exception ? e : Exception(e.toString())));
         dispatchUpdates();
         if (!completer.isCompleted) completer.complete();
       },
@@ -343,18 +430,26 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     return lastPage?.nextKey ?? lastPage?.prevKey;
   }
 
+  K? get _prevPageKey {
+    final firstPage = _pages.firstOrNull;
+    return firstPage?.prevKey;
+  }
+
   FutureOr<void> _requestRemoteLoad(LoadType loadType) async {
     if (_remoteMediator == null) return;
-    if (loadType == LoadType.APPEND &&
-        _mediatorStates.append.endOfPaginationReached) return;
-    if (loadType == LoadType.REFRESH &&
-        _mediatorStates.refresh.endOfPaginationReached) return;
+    final current = _mediatorStates.get(loadType);
+    if (current.endOfPaginationReached) return;
+    // Refresh is fired outside the lock (initial load), so it also needs an
+    // overlapping-call guard; append/prepend are serialized by _doLoad.
+    if (loadType == LoadType.REFRESH && current is Loading) return;
 
     _mediatorStates = _mediatorStates.modifyState(loadType, Loading());
     dispatchUpdates();
 
+    final pageKey =
+        loadType == LoadType.PREPEND ? _prevPageKey : _nextPageKey;
     final result = await _remoteMediator!
-        .load(loadType, PagingState<K, T>(_nextPageKey, pagingConfig));
+        .load(loadType, PagingState<K, T>(pageKey, pagingConfig));
 
     if (_disposed) return;
 
@@ -388,39 +483,56 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
     oldPage.data.addAll(newPage.data);
     if (oldPage.data.isEmpty) {
       final idx = _pages.indexOf(oldPage);
-      if (idx != -1) {
-        _pages.removeAt(idx);
-        _rebuildPageIndex();
-      }
+      if (idx != -1) _removePageAt(idx);
     }
     return false; // changed
   }
 
-  void _rebuildPageIndex() {
-    _pageIndex.clear();
-    for (int i = 0; i < _pages.length; i++) {
-      _pageIndex[_pages[i].prevKey] = i;
-    }
+  /// Inserts [page] at the front of [_pages], registered under [positionKey].
+  void _insertPageAtFront(K? positionKey, Page<K, T> page) {
+    _pages.insert(0, page);
+    _pageIndex.updateAll((key, value) => value + 1);
+    _pageIndex[positionKey] = 0;
+  }
+
+  /// Removes the page at [index] and shifts [_pageIndex] entries accordingly,
+  /// preserving each surviving page's original position key (null for the
+  /// refresh page, load cursor for appended/prepended pages).
+  void _removePageAt(int index) {
+    _pages.removeAt(index);
+    _pageIndex.removeWhere((key, value) => value == index);
+    _pageIndex.updateAll((key, value) => value > index ? value - 1 : value);
   }
 
   /// Inserts or updates a page identified by [positionKey].
   ///
   /// [positionKey] for the first (refresh) page is always `null`.
-  /// For appended pages it is [LoadParams.key] — the nextKey of the previous
-  /// page — which gives O(1) lookup via [_pageIndex].
-  void _insertOrUpdate(K? positionKey, Page<K, T> page) {
+  /// For appended and prepended pages it is [LoadParams.key] — the boundary
+  /// key of the neighbouring page the load was issued from — which gives O(1)
+  /// lookup via [_pageIndex]. Prepended pages must NOT be keyed by their own
+  /// prevKey: the topmost page's prevKey is null, which would collide with the
+  /// refresh page's slot.
+  void _insertOrUpdate(K? positionKey, Page<K, T> page,
+      {bool prepend = false}) {
     bool inserted = false;
 
     if (positionKey == null) {
-      // First page slot.
+      // Refresh page slot. Resolved via _pageIndex — after a prepend the
+      // refresh page is no longer _pages.first.
+      final index = _pageIndex[null];
       if (_pages.isEmpty) {
         if (!page.isEmpty()) {
           _pages.add(page);
           _pageIndex[positionKey] = 0;
           inserted = true;
         }
-      } else {
-        inserted = !_calculateDiffAndUpdate(_pages.first, page);
+      } else if (index != null && index < _pages.length) {
+        inserted = !_calculateDiffAndUpdate(_pages[index], page);
+      } else if (!page.isEmpty()) {
+        // The refresh page was removed (emptied by a reactive update) while
+        // other pages remain — re-insert it at the front.
+        _insertPageAtFront(positionKey, page);
+        inserted = true;
       }
     } else {
       if (_pages.isEmpty) {
@@ -429,14 +541,15 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
       }
 
       final index = _pageIndex[positionKey];
-
       if (index == null && page.data.isNotEmpty) {
-        // New page — append it.
-        _pageIndex[positionKey] = _pages.length;
-        _pages.add(page);
+        if (prepend) {
+          _insertPageAtFront(positionKey, page);
+        } else {
+          _pageIndex[positionKey] = _pages.length;
+          _pages.add(page);
+        }
         inserted = true;
       } else if (index != null && index < _pages.length) {
-        // Existing page — diff and update.
         inserted = !_calculateDiffAndUpdate(_pages[index], page);
       }
     }
@@ -495,7 +608,8 @@ class PagerController<K, T> extends ValueNotifier<PagingData<T>> {
 
   void dispatchUpdates() {
     if (_disposed) return;
-    _states = _states.combineStates(_sourceStates, _mediatorStates);
+    _states = _states.combineStates(_sourceStates, _mediatorStates,
+        hasMediator: _remoteMediator != null);
     final combined = CombinedLoadStates(
         _states.refresh, _states.append, _states.prepend,
         source: _sourceStates,

--- a/test/pager_controller_test.dart
+++ b/test/pager_controller_test.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pager/pager.dart';
+
+/// Builds page [p] of [totalPages]: 3 items per page, page-number keys.
+/// prevKey/nextKey are null at the respective boundaries.
+Page<int, String> pageAt(int p, int totalPages) => Page(
+      List.generate(3, (i) => 'item${p * 3 + i}'),
+      p > 0 ? p - 1 : null,
+      p < totalPages - 1 ? p + 1 : null,
+    );
+
+/// One-shot source over pages 0..totalPages-1. REFRESH loads [startPage];
+/// APPEND/PREPEND load the page named by the cursor.
+PagingSource<int, String> pagedSource({
+  required int startPage,
+  required int totalPages,
+}) {
+  return PagingSource(
+    localSource: (params) =>
+        Stream.value(pageAt(params.key ?? startPage, totalPages)),
+  );
+}
+
+class FakeMediator extends RemoteMediator<int, String> {
+  FakeMediator(this.onLoad);
+
+  final Future<MediatorResult> Function(LoadType type, int? cursor) onLoad;
+  final List<LoadType> calls = [];
+
+  @override
+  Future<MediatorResult> load(LoadType loadType, PagingState pagingState) {
+    calls.add(loadType);
+    return onLoad(loadType, pagingState.nextKey as int?);
+  }
+}
+
+void main() {
+  group('prepend', () {
+    test('prepends pages in order until the first page is reached', () async {
+      final controller = PagerController<int, String>(
+          source: pagedSource(startPage: 2, totalPages: 5));
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item6', 'item7', 'item8']);
+
+      controller.triggerPrepend();
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item3', 'item4', 'item5', 'item6', 'item7', 'item8']);
+
+      controller.triggerPrepend();
+      await pumpEventQueue();
+      expect(controller.items, List.generate(9, (i) => 'item$i'));
+      expect(controller.loadStates?.prepend.endOfPaginationReached, isTrue);
+
+      controller.dispose();
+    });
+
+    test('a non-empty top page with null prevKey does not overwrite the '
+        'refresh page', () async {
+      final controller = PagerController<int, String>(
+          source: pagedSource(startPage: 1, totalPages: 5));
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item3', 'item4', 'item5']);
+
+      // Page 0 arrives with prevKey == null; it must be inserted in front of
+      // the refresh page, not diffed into its slot via the null index key.
+      controller.triggerPrepend();
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item0', 'item1', 'item2', 'item3', 'item4', 'item5']);
+      expect(controller.loadStates?.prepend.endOfPaginationReached, isTrue);
+
+      controller.dispose();
+    });
+
+    test('reactive refresh emissions update the refresh page, not the '
+        'prepended page', () async {
+      final refreshStream = StreamController<Page<int, String>>();
+      final source = PagingSource<int, String>(
+        localSource: (params) {
+          if (params.key == null) return refreshStream.stream;
+          return Stream.value(pageAt(params.key!, 5));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+
+      refreshStream.add(pageAt(1, 5));
+      await pumpEventQueue();
+      expect(controller.items, ['item3', 'item4', 'item5']);
+
+      controller.triggerPrepend();
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item0', 'item1', 'item2', 'item3', 'item4', 'item5']);
+
+      // The refresh query re-emits (e.g. a DB watcher) with changed data.
+      // The update must land on the refresh page — now at index 1 — and must
+      // not clobber the prepended page at the front.
+      refreshStream.add(Page(['item3', 'item4', 'CHANGED'], 0, 2));
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item0', 'item1', 'item2', 'item3', 'item4', 'CHANGED']);
+
+      controller.dispose();
+      await refreshStream.close();
+    });
+
+    test('empty prepend result without a mediator ends pagination instead of '
+        'looping', () async {
+      var prependLoads = 0;
+      final source = PagingSource<int, String>(
+        localSource: (params) {
+          if (params.key == null) {
+            return Stream.value(Page(['a', 'b', 'c'], 0, null));
+          }
+          prependLoads++;
+          return Stream.value(Page(<String>[], null, null));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+
+      controller.triggerPrepend();
+      await pumpEventQueue();
+
+      expect(controller.items, ['a', 'b', 'c']);
+      expect(controller.loadStates?.prepend.endOfPaginationReached, isTrue);
+      // Exactly one local load — no self-re-triggering without a mediator.
+      expect(prependLoads, 1);
+
+      controller.dispose();
+    });
+  });
+
+  group('remote mediator prepend', () {
+    test('cache miss triggers a mediator fetch and loads the fetched page',
+        () async {
+      final store = <int, Page<int, String>>{1: pageAt(1, 3)};
+      final mediator = FakeMediator((type, cursor) async {
+        switch (type) {
+          case LoadType.REFRESH:
+            return MediatorResult.success(endOfPaginationReached: false);
+          case LoadType.PREPEND:
+            if (cursor == null) {
+              return MediatorResult.success(endOfPaginationReached: true);
+            }
+            // "Fetch" the page from the server into the local store.
+            store[cursor] = pageAt(cursor, 3);
+            return MediatorResult.success(endOfPaginationReached: false);
+          case LoadType.APPEND:
+            return MediatorResult.success(endOfPaginationReached: true);
+        }
+      });
+      final source = PagingSource<int, String>(
+        remoteMediator: mediator,
+        localSource: (params) {
+          final key = params.key ?? 1;
+          return Stream.value(store[key] ?? Page(<String>[], null, null));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item3', 'item4', 'item5']);
+
+      // Cursor 0 misses the cache → mediator fetches page 0 → the load
+      // re-triggers and picks it up.
+      controller.triggerPrepend();
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item0', 'item1', 'item2', 'item3', 'item4', 'item5']);
+      expect(controller.loadStates?.prepend.endOfPaginationReached, isTrue);
+      expect(mediator.calls.where((c) => c == LoadType.PREPEND).length, 2);
+
+      controller.dispose();
+    });
+
+    test('mediator prepend errors surface in the combined load states',
+        () async {
+      final store = <int, Page<int, String>>{1: pageAt(1, 3)};
+      final mediator = FakeMediator((type, cursor) async {
+        if (type == LoadType.PREPEND) {
+          return MediatorResult.error(exception: Exception('boom'));
+        }
+        return MediatorResult.success(endOfPaginationReached: false);
+      });
+      final source = PagingSource<int, String>(
+        remoteMediator: mediator,
+        localSource: (params) {
+          final key = params.key ?? 1;
+          return Stream.value(store[key] ?? Page(<String>[], null, null));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+
+      controller.triggerPrepend();
+      await pumpEventQueue();
+
+      expect(controller.items, ['item3', 'item4', 'item5']);
+      expect(controller.loadStates?.prepend, isA<Error>());
+      // The failed load must not chain into another attempt.
+      expect(mediator.calls.where((c) => c == LoadType.PREPEND).length, 1);
+
+      controller.dispose();
+    });
+  });
+
+  group('scroll boundary', () {
+    test('scroll events at exhausted boundaries do not redispatch', () async {
+      final mediator = FakeMediator((type, cursor) async =>
+          MediatorResult.success(endOfPaginationReached: false));
+      final source = PagingSource<int, String>(
+        remoteMediator: mediator,
+        localSource: (params) => Stream.value(pageAt(0, 1)),
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      // Single page with null prevKey and nextKey: scrolling near either
+      // boundary must neither notify listeners nor consult the mediator.
+      for (var i = 0; i < 5; i++) {
+        controller.onScrollPositionChanged(0, 300);
+        await pumpEventQueue();
+      }
+
+      expect(notifications, 0);
+      expect(mediator.calls, [LoadType.REFRESH]);
+
+      controller.dispose();
+    });
+  });
+
+  group('append', () {
+    test('appends pages until the last page is reached', () async {
+      final controller = PagerController<int, String>(
+          source: pagedSource(startPage: 0, totalPages: 3));
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      controller.triggerAppend();
+      await pumpEventQueue();
+      controller.triggerAppend();
+      await pumpEventQueue();
+
+      expect(controller.items, List.generate(9, (i) => 'item$i'));
+      expect(controller.endOfPaginationReached, isTrue);
+
+      controller.dispose();
+    });
+  });
+
+  group('LoadStates.combineStates', () {
+    LoadStates idle() => LoadStates.idle();
+
+    test('preserves local source errors when a mediator is present', () {
+      final local = LoadStates(
+          NotLoading(false), Error(Exception('x')), NotLoading(false));
+      final combined =
+          idle().combineStates(local, idle(), hasMediator: true);
+      expect(combined.append, isA<Error>());
+    });
+
+    test('surfaces mediator errors', () {
+      final remote = LoadStates(
+          NotLoading(false), NotLoading(false), Error(Exception('x')));
+      final combined =
+          idle().combineStates(idle(), remote, hasMediator: true);
+      expect(combined.prepend, isA<Error>());
+    });
+
+    test('keeps local Loading visible with a mediator', () {
+      final local =
+          LoadStates(NotLoading(false), Loading(), NotLoading(false));
+      final combined =
+          idle().combineStates(local, idle(), hasMediator: true);
+      expect(combined.append, isA<Loading>());
+    });
+
+    test('remote Loading takes precedence', () {
+      final remote =
+          LoadStates(NotLoading(false), NotLoading(false), Loading());
+      final combined =
+          idle().combineStates(idle(), remote, hasMediator: true);
+      expect(combined.prepend, isA<Loading>());
+    });
+
+    test('end of pagination requires both sides with a mediator', () {
+      final local =
+          LoadStates(NotLoading(false), NotLoading(true), NotLoading(true));
+      final remoteOpen =
+          LoadStates(NotLoading(false), NotLoading(false), NotLoading(false));
+      final remoteEnded =
+          LoadStates(NotLoading(false), NotLoading(true), NotLoading(true));
+
+      final open = idle().combineStates(local, remoteOpen, hasMediator: true);
+      expect(open.append.endOfPaginationReached, isFalse);
+      expect(open.prepend.endOfPaginationReached, isFalse);
+
+      final ended =
+          idle().combineStates(local, remoteEnded, hasMediator: true);
+      expect(ended.append.endOfPaginationReached, isTrue);
+      expect(ended.prepend.endOfPaginationReached, isTrue);
+    });
+
+    test('without a mediator local state passes through', () {
+      final local =
+          LoadStates(NotLoading(false), NotLoading(true), NotLoading(true));
+      final combined = idle().combineStates(local, idle());
+      expect(combined.append.endOfPaginationReached, isTrue);
+      expect(combined.prepend.endOfPaginationReached, isTrue);
+    });
+
+    test('local refresh errors are preserved', () {
+      final local = LoadStates(
+          Error(Exception('x')), NotLoading(false), NotLoading(false));
+      final combined =
+          idle().combineStates(local, idle(), hasMediator: true);
+      expect(combined.refresh, isA<Error>());
+    });
+  });
+}

--- a/test/pager_controller_test.dart
+++ b/test/pager_controller_test.dart
@@ -245,6 +245,109 @@ void main() {
   });
 
   group('append', () {
+    test('append with a mediator: cache miss fetches remotely, next scroll '
+        'picks up the fetched page', () async {
+      final store = <int, Page<int, String>>{0: pageAt(0, 2)};
+      final mediator = FakeMediator((type, cursor) async {
+        if (type == LoadType.APPEND && cursor != null) {
+          // "Fetch" the page from the server into the local store.
+          store[cursor] = pageAt(cursor, 2);
+        }
+        return MediatorResult.success(endOfPaginationReached: false);
+      });
+      final source = PagingSource<int, String>(
+        remoteMediator: mediator,
+        localSource: (params) {
+          final key = params.key ?? 0;
+          return Stream.value(store[key] ?? Page(<String>[], null, null));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      // Scroll near the bottom: cursor 1 misses the cache → mediator fetches.
+      controller.onScrollPositionChanged(100, 100);
+      await pumpEventQueue();
+      // Appends do not auto-re-trigger after a mediator fetch (unlike
+      // prepends) — the fetched page is picked up by the next scroll event.
+      expect(controller.items, ['item0', 'item1', 'item2']);
+      expect(mediator.calls.where((c) => c == LoadType.APPEND).length, 1);
+
+      controller.onScrollPositionChanged(100, 100);
+      await pumpEventQueue();
+      expect(controller.items, List.generate(6, (i) => 'item$i'));
+
+      controller.dispose();
+    });
+
+    test('append errors surface and retry() recovers with a mediator present',
+        () async {
+      var failAppend = true;
+      final mediator = FakeMediator((type, cursor) async =>
+          MediatorResult.success(endOfPaginationReached: false));
+      final source = PagingSource<int, String>(
+        remoteMediator: mediator,
+        localSource: (params) {
+          if (params.key == null) return Stream.value(pageAt(0, 2));
+          if (failAppend) {
+            return Stream.error(Exception('disk failure'));
+          }
+          return Stream.value(pageAt(params.key!, 2));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      controller.triggerAppend();
+      await pumpEventQueue();
+      expect(controller.hasError, isTrue);
+      expect(controller.appendError, isNotNull);
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      failAppend = false;
+      await controller.retry();
+      await pumpEventQueue();
+      expect(controller.hasError, isFalse);
+      expect(controller.items, List.generate(6, (i) => 'item$i'));
+
+      controller.dispose();
+    });
+
+    test('reactive refresh emissions update the refresh page after appends',
+        () async {
+      final refreshStream = StreamController<Page<int, String>>();
+      final source = PagingSource<int, String>(
+        localSource: (params) {
+          if (params.key == null) return refreshStream.stream;
+          return Stream.value(pageAt(params.key!, 2));
+        },
+      );
+      final controller = PagerController<int, String>(source: source);
+      controller.initialize();
+      await pumpEventQueue();
+      refreshStream.add(pageAt(0, 2));
+      await pumpEventQueue();
+      expect(controller.items, ['item0', 'item1', 'item2']);
+
+      controller.triggerAppend();
+      await pumpEventQueue();
+      expect(controller.items, List.generate(6, (i) => 'item$i'));
+
+      // The refresh query re-emits with changed data; the update must land on
+      // the refresh page without disturbing the appended page.
+      refreshStream.add(Page(['item0', 'CHANGED', 'item2'], null, 1));
+      await pumpEventQueue();
+      expect(controller.items,
+          ['item0', 'CHANGED', 'item2', 'item3', 'item4', 'item5']);
+
+      controller.dispose();
+      await refreshStream.close();
+    });
+
     test('appends pages until the last page is reached', () async {
       final controller = PagerController<int, String>(
           source: pagedSource(startPage: 0, totalPages: 3));


### PR DESCRIPTION
## Summary

Adds bidirectional paging (prepend) support to `PagerController`, alongside correctness fixes surfaced while building it.

### Feature
- Scroll-triggered **prepend** loads when the viewport nears the top, symmetric with the existing append behavior
- `triggerPrepend()` / `triggerAppend()` public APIs for manual loads that bypass end-of-pagination guards (e.g. "check the server for newer items")
- `RemoteMediator` is consulted for `LoadType.PREPEND` with the first page's `prevKey` as cursor; after a mediator fetch saves new data, the prepend re-triggers itself to pick it up (guarded against errors, exhaustion, and missing mediators so empty results can never loop)

### Implementation notes
- Append and prepend share one pipeline: a single `_onDirectionalLoad` handler, one `_doLoad` body parameterized by direction, and shared guards built on a new `LoadStates.get(LoadType)` accessor
- Prepended pages are keyed in the page index by their **load cursor** (like appends), so a non-empty top page with a null `prevKey` can't collide with the refresh page's slot
- Reactive refresh emissions resolve the refresh page through the index instead of assuming `_pages.first`, so they can't clobber a prepended page

### Fixes
- `combineStates`: with a mediator, `endOfPaginationReached` now requires **both** source and mediator to agree (no more premature "end of list" when the local cache runs dry), and `Error`/`Loading` states from either side are never masked — `hasError`, `appendError`, and `retry()` work again for mediator-based sources
- Exhausted-boundary scroll events only dispatch on real state transitions, eliminating a UI rebuild per scroll frame near the list edges

### Tests
13 new headless `PagerController` tests (`test/pager_controller_test.dart`): prepend ordering to the top boundary, null-`prevKey` top page not corrupting the refresh page, reactive refresh emissions after a prepend, empty-result termination, mediator cache-miss fetch → re-trigger flow, mediator error surfacing, scroll-boundary notification silence, an append regression test, and `combineStates` precedence. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
